### PR TITLE
Such warn_unused_result, wow

### DIFF
--- a/tests/escapes.c
+++ b/tests/escapes.c
@@ -25,11 +25,19 @@ static char *wag(char *in) {
 
     if (out_len != in_len) {
         free(out);
-        asprintf(&err, "length mismatch: expected %zd, got %zd", in_len,
-                 out_len);
+        int ret = asprintf(&err, "length mismatch: expected %zd, got %zd",
+                           in_len, out_len);
+        if (ret < 0) {
+            fprintf(stderr, "allocation failed!\n");
+            exit(1);
+        }
         return err;
     } else if (strcmp(in, out)) {
-        asprintf(&err, "strings don't match - got %s\n", out);
+        int ret = asprintf(&err, "strings don't match - got %s\n", out);
+        if (ret < 0) {
+            fprintf(stderr, "allocation failed!\n");
+            exit(1);
+        }
         free(out);
         return err;
     }


### PR DESCRIPTION
I'm packaging cdson for NixOS and I ran into the following warning when building:
```
FAILED: escapes.p/tests_escapes.c.o 
gcc -Iescapes.p -I. -I.. -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c99 -D_GNU_SOURCE -MD -MQ escapes.p/tests_escapes.c.o -MF escapes.p/tests_escapes.c.o.d -o escapes.p/tests_escapes.c.o -c ../tests/escapes.c
../tests/escapes.c: In function 'wag':
../tests/escapes.c:28:9: error: ignoring return value of 'asprintf' declared with attribute 'warn_unused_result' [-Werror=unused-result]
   28 |         asprintf(&err, "length mismatch: expected %zd, got %zd", in_len,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   29 |                  out_len);
      |                  ~~~~~~~~
../tests/escapes.c:32:9: error: ignoring return value of 'asprintf' declared with attribute 'warn_unused_result' [-Werror=unused-result]
   32 |         asprintf(&err, "strings don't match - got %s\n", out);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

Using ninja 1.11.1. Not sure why I don't get the warning when compiling on Fedora 38, maybe it's the newer compiler or maybe it has to do with NixOS's hardening. Either way, a quick fix.